### PR TITLE
Add missing POTFILES.in for intltool-update support

### DIFF
--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -1,0 +1,17 @@
+# List of source files containing translatable strings
+# Format: one file path per line, relative to project root
+
+setup-station-init
+setup_station/__init__.py
+setup_station/add_admin.py
+setup_station/add_users.py
+setup_station/common.py
+setup_station/data.py
+setup_station/interface_controller.py
+setup_station/keyboard.py
+setup_station/language.py
+setup_station/network_setup.py
+setup_station/setup_system.py
+setup_station/system_calls.py
+setup_station/timezone.py
+setup_station/window.py


### PR DESCRIPTION
## Summary by Sourcery

Build:
- Add POTFILES.in listing translatable sources so intltool-update can regenerate the message catalog correctly.