### PR TITLE
Replace autologin shrc approach with rc.d service

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ from DistUtilsExtra.command.build_i18n import build_i18n
 from DistUtilsExtra.command.clean_i18n import clean_i18n
 
 prefix = sys.prefix
-__VERSION__ = '0.1'
+__VERSION__ = '0.3'
 PROGRAM_VERSION = __VERSION__
 
 
@@ -142,7 +142,8 @@ lib_setup_station_image = [
 data_files = [
     (f'{prefix}/lib/setup-station', ['src/ghostbsd-style.css']),
     (f'{prefix}/lib/setup-station/image', lib_setup_station_image),
-    (f'{prefix}/share/applications', ['src/setup-station.desktop'])
+    (f'{prefix}/share/applications', ['src/setup-station.desktop']),
+    (f'{prefix}/etc/rc.d', ['src/ghostbsd_setup'])
 ]
 
 # Add locale files if they exist

--- a/setup.py
+++ b/setup.py
@@ -143,7 +143,7 @@ data_files = [
     (f'{prefix}/lib/setup-station', ['src/ghostbsd-style.css']),
     (f'{prefix}/lib/setup-station/image', lib_setup_station_image),
     (f'{prefix}/share/applications', ['src/setup-station.desktop']),
-    (f'{prefix}/etc/rc.d', ['src/ghostbsd_setup'])
+    (f'{prefix}/etc/rc.d', ['src/initial_setup'])
 ]
 
 # Add locale files if they exist

--- a/setup_station/setup_system.py
+++ b/setup_station/setup_system.py
@@ -39,8 +39,7 @@ def setup_system(progress_bar: Gtk.ProgressBar) -> None:
     from setup_station.add_admin import AddAdminUser
     from setup_station.system_calls import (
         enable_lightdm,
-        remove_ghostbsd_autologin,
-        start_lightdm
+        remove_ghostbsd_autologin
     )
 
     # Step 0/6: Setting system language
@@ -77,7 +76,7 @@ def setup_system(progress_bar: Gtk.ProgressBar) -> None:
     GLib.idle_add(update_progress, progress_bar, 1, get_text("Setup complete!"))
     sleep(1)
 
-    # Update label text before starting lightdm
+    # Update label text before exiting
     def update_label():
         SetupWindow.slide_text.set_markup(
             get_text("Configuration complete.") +
@@ -88,11 +87,8 @@ def setup_system(progress_bar: Gtk.ProgressBar) -> None:
     GLib.idle_add(update_label)
     sleep(2)
 
-    # Start lightdm and exit
-    start_lightdm()
-
-    import sys
-    sys.exit(0)
+    # Quit GTK main loop - X will exit and rc.d service will continue boot to lightdm
+    GLib.idle_add(Gtk.main_quit)
 
 
 class SetupWindow:

--- a/src/ghostbsd_setup
+++ b/src/ghostbsd_setup
@@ -1,0 +1,36 @@
+#!/bin/sh
+#
+# PROVIDE: ghostbsd_setup
+# REQUIRE: LOGIN FILESYSTEMS
+# BEFORE: lightdm
+# KEYWORD: shutdown
+
+. /etc/rc.subr
+
+name="ghostbsd_setup"
+rcvar="${name}_enable"
+start_cmd="${name}_start"
+stop_cmd=":"
+
+ghostbsd_setup_start()
+{
+    # Create .xinitrc for root to run setup
+    cat > /root/.xinitrc <<'EOF'
+exec marco &
+exec feh --bg-fill /usr/local/share/backgrounds/ghostbsd/blue-layered-stripes.jpg &
+exec setup-station-init
+EOF
+    chmod 755 /root/.xinitrc
+
+    # Start X as root - this will block until setup-station-init exits
+    su -l root -c "startx -- :0 vt09"
+
+    # Cleanup
+    rm -f /root/.xinitrc
+
+    # Disable this service for future boots
+    sysrc ghostbsd_setup_enable=NO
+}
+
+load_rc_config $name
+run_rc_command "$1"

--- a/src/initial_setup
+++ b/src/initial_setup
@@ -1,18 +1,18 @@
 #!/bin/sh
 #
-# PROVIDE: ghostbsd_setup
+# PROVIDE: initial_setup
 # REQUIRE: LOGIN FILESYSTEMS
 # BEFORE: lightdm
 # KEYWORD: shutdown
 
 . /etc/rc.subr
 
-name="ghostbsd_setup"
+name="initial_setup"
 rcvar="${name}_enable"
 start_cmd="${name}_start"
 stop_cmd=":"
 
-ghostbsd_setup_start()
+initial_setup_start()
 {
     # Create .xinitrc for root to run setup
     cat > /root/.xinitrc <<'EOF'
@@ -29,7 +29,7 @@ EOF
     rm -f /root/.xinitrc
 
     # Disable this service for future boots
-    sysrc ghostbsd_setup_enable=NO
+    sysrc initial_setup_enable=NO
 }
 
 load_rc_config $name


### PR DESCRIPTION
Instead of using autologin with shrc to run the setup, implement a cleaner
rc.d service that handles the setup-to-lightdm transition. The setup app now
exits cleanly via Gtk.main_quit() and lets the rc.d service continue boot.

  - Bump version from 0.1 to 0.3
  - Add ghostbsd_setup rc.d script installation
  - Replace direct lightdm startup with Gtk.main_quit()
  - Remove start_lightdm import and call

## Summary by Sourcery

Replace the autologin-based setup completion with an rc.d service–driven transition to lightdm and update the package version accordingly.

New Features:
- Install an initial_setup rc.d script to manage the transition from the setup application to lightdm during boot.

Enhancements:
- Change the setup application to exit via Gtk.main_quit instead of directly starting lightdm and terminating the process.
- Bump the application version from 0.1 to 0.3 to reflect the new startup mechanism.